### PR TITLE
Add brew tap to goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,3 +34,13 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+brews:
+  -
+    name: steward
+    homepage: "https://github.com/RaaLabs/steward"
+    # The GitHub repository to push the forula to
+    tap:
+      owner: raalabs
+      name: homebrew-raalabs
+      branch: main
+      token: {{ secrets.RAALABS_BREW_TAP_TOKEN_STEWARD }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - darwin
     main: ./cmd/steward/main.go
     binary: steward
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,7 @@ brews:
   -
     name: steward
     homepage: "https://github.com/RaaLabs/steward"
-    # The GitHub repository to push the forula to
+    # The GitHub repository to push the forumla to
     tap:
       owner: raalabs
       name: homebrew-raalabs


### PR DESCRIPTION
Add a brew tap to the .goreleaser.yaml file.

This will publish the release created earlier in the build to the RaaLabs brew tap. Afterwards it should be possible to install steward like this:

```bash
brew tap raalabs/raalabs
brew install steward
```