### PR TITLE
Reserve `local` as a nodeName for all readers

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.20
 
     - name: Build
       run: go build -v cmd/steward/main.go

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: 1.20.5
 
     - name: Build
       run: go build -v cmd/steward/main.go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '>=1.18.0'
+        go-version: '>=1.20.0'
     - name: Login to GHCR
       uses: docker/login-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.17.7-alpine AS build-env
+FROM golang:1.20-alpine AS build-env
 RUN apk --no-cache add build-base git gcc
 
 RUN mkdir -p /build

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ As an example. If You want to place a message on the startup folder of **node1**
 
 #### Use local as the toNode nodename
 
-Since messages used in startup folder are ment to be delivered locally we can simply things a bit by setting the **toNode** field value of the message to **local**.
+Set the `toNode` field of your message to **local** in order to send the message to yourself, this can be helpful when using the startup folder, or if you have some other process interacting with your running steward instance.
 
 ```json
 [

--- a/message_readers.go
+++ b/message_readers.go
@@ -83,7 +83,7 @@ func (s *server) readStartupFolder() {
 
 		// Check if fromNode field is specified, and remove the message if blank.
 		for i := range sams {
-			// We want to allow the use of nodeName local only in startup folder, and
+			// We want to allow the use of nodeName local, and
 			// if used we substite it for the local node name.
 			if sams[i].Message.ToNode == "local" {
 				sams[i].Message.ToNode = Node(s.nodeName)
@@ -199,7 +199,10 @@ func (s *server) readSocket() {
 			}
 
 			for i := range sams {
-
+				if sams[i].Message.ToNode == "local" {
+					sams[i].Message.ToNode = Node(s.nodeName)
+					sams[i].Subject.ToNode = s.nodeName
+				}
 				// Fill in the value for the FromNode field, so the receiver
 				// can check this field to know where it came from.
 				sams[i].Message.FromNode = Node(s.nodeName)
@@ -277,6 +280,10 @@ func (s *server) readFolder() {
 						}
 
 						for i := range sams {
+							if sams[i].Message.ToNode == "local" {
+								sams[i].Message.ToNode = Node(s.nodeName)
+								sams[i].Subject.ToNode = s.nodeName
+							}
 
 							// Fill in the value for the FromNode field, so the receiver
 							// can check this field to know where it came from.

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -284,7 +284,6 @@ func (r *ringBuffer) processBufferMessages(ctx context.Context, ringBufferOutCh 
 				// Create a ticker that will kick in when a message have been in the
 				// system for it's maximum time. This will allow us to continue, and
 				// remove the message if it takes longer than it should to get delivered.
-				fmt.Printf("DEBUG:::%v\n", v.SAM.ACKTimeout)
 				if v.SAM.ACKTimeout <= 0 {
 					v.SAM.ACKTimeout = 1
 				}


### PR DESCRIPTION
f39f3d73c7b13ed707b31d6681803c2063028a8c allowed the use of `toNode: "local"` for messages in the startup folder allowing you to specify this recipient and have the message sent to yourself.

There are cases outside of startupFolder where this functionality is helpful.

This PR adds the functionality to `readFolder` and socket access.

Also updated the build deps to Go 1.20 since slog won't build otherwise